### PR TITLE
Don't fade out tooltip if still grabbed

### DIFF
--- a/dist/navigator-tooltip.js
+++ b/dist/navigator-tooltip.js
@@ -197,9 +197,8 @@ var wrap = _window$Highcharts.wrap;
       if (grabbed) {
         fadeInTooltip(_this, position);
         adjustTooltip(_this, position, formattedTooltipText[position]);
-        setTimeout(function () {
-          fadeOutTooltip(_this, position);
-        }, 1000);
+      } else {
+        fadeOutTooltip(_this, position);
       }
     });
   });

--- a/src/navigator-tooltip.js
+++ b/src/navigator-tooltip.js
@@ -170,9 +170,8 @@ const { Highcharts: { Scroller, wrap } } = window;
       if (grabbed) {
         fadeInTooltip(this, position);
         adjustTooltip(this, position, formattedTooltipText[position]);
-        setTimeout(() => {
-          fadeOutTooltip(this, position);
-        }, 1000);
+      } else {
+        fadeOutTooltip(this, position);
       }
     });
   });


### PR DESCRIPTION
We need the tooltip to stay up as long as the handle is grabbed, this is my method of doing that. If you want to preserve the option for fade out while grabbed, I can rework for having an option for that but I wasn't sure how important that feature was.
